### PR TITLE
Fixing version qualifier of validation-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 			<dependency>
   				<groupId>javax.validation</groupId>
  				 <artifactId>validation-api</artifactId>
-  				<version>1.1.0.FINAL</version>
+  				<version>1.1.0.Final</version>
   				<scope>compile</scope>
 			</dependency>
 


### PR DESCRIPTION
Maven is case-insensitive about version qualifiers, but repository proxies may fail to look up this artifact (e.g. Nexus OSS).