### PR TITLE
Dependency version updated for hibernate-validator to resolve conflict with javax.validation:validation-api:1.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.socialsignin</groupId>
     <artifactId>spring-data-dynamodb</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>Spring Data DynamoDb</name>
     <description>Spring Data module providing support for DynamoDb repositories.</description>
     <url>http://github.com/michaellavelle/spring-data-dynamodb</url>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.2.0.Final</version>
+            <version>5.1.3.Final</version>
         </dependency>
 
         <!-- APACHE -->
@@ -222,7 +222,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<!-- 
+			<!--
             <plugin>
                 <groupId>com.jcabi</groupId>
                 <artifactId>jcabi-dynamodb-maven-plugin</artifactId>


### PR DESCRIPTION
Previously, the project depended on org.hibernate:hibernate-validator:4.2.0.Final and javax.validation:validation-api:1.1.0.Final.  The hibernate-validator dependency also depends on javax.validation:validation-api:1.0.0.GA.  As a result, both of these depdencies clash and cause run-time errors when trying to use this library.  I've updated the hibernate-validator dependency to use 5.1.3.GA which uses the same version declared in this project.  I've tested using this new modification to another example project, and I don't receive the run-time errors that were showing a conflict between the two dependencies.

This should fix #60 