### PR TITLE
Respect the pagination size for queries

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/AbstractDynamoDBQueryCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/AbstractDynamoDBQueryCriteria.java
@@ -30,6 +30,7 @@ import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.mapping.DefaultDynamoDBDateMarshaller;
 import org.socialsignin.spring.data.dynamodb.query.Query;
 import org.socialsignin.spring.data.dynamodb.repository.support.DynamoDBEntityInformation;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
@@ -63,6 +64,7 @@ public abstract class AbstractDynamoDBQueryCriteria<T, ID extends Serializable> 
 	protected Object hashKeyPropertyValue;
 	protected String globalSecondaryIndexName;
 	protected Sort sort;
+	protected Pageable pageable;
 
 	public abstract boolean isApplicableForLoad();
 
@@ -111,7 +113,14 @@ public abstract class AbstractDynamoDBQueryCriteria<T, ID extends Serializable> 
 			queryRequest.setSelect(Select.ALL_PROJECTED_ATTRIBUTES);
 			applySortIfSpecified(queryRequest, new ArrayList<String>(new HashSet<String>(allowedSortProperties)));
 		}
+		applyPageableIfSpecified(queryRequest);
 		return queryRequest;
+	}
+
+	private void applyPageableIfSpecified(QueryRequest queryRequest) {
+		if (pageable != null) {
+			queryRequest.setLimit(pageable.getPageSize());
+		}
 	}
 
 	protected void applySortIfSpecified(DynamoDBQueryExpression<T> queryExpression, List<String> permittedPropertyNames) {
@@ -628,6 +637,12 @@ public abstract class AbstractDynamoDBQueryCriteria<T, ID extends Serializable> 
 	@Override
 	public DynamoDBQueryCriteria<T, ID> withSort(Sort sort) {
 		this.sort = sort;
+		return this;
+	}
+
+	@Override
+	public DynamoDBQueryCriteria<T, ID> withPageable(Pageable pageable) {
+		this.pageable = pageable;
 		return this;
 	}
 

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCreator.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCreator.java
@@ -5,16 +5,20 @@ import java.io.Serializable;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.query.Query;
 import org.socialsignin.spring.data.dynamodb.repository.support.DynamoDBEntityInformation;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.parser.PartTree;
 
 public class DynamoDBQueryCreator<T,ID extends Serializable> extends AbstractDynamoDBQueryCreator<T, ID,T> {
 
+	private final Pageable pageable;
+
 	public DynamoDBQueryCreator(PartTree tree,
 			DynamoDBEntityInformation<T, ID> entityMetadata,
 			DynamoDBOperations dynamoDBOperations) {
 		super(tree, entityMetadata, dynamoDBOperations);
+		pageable = null;
 	}
 
 	public DynamoDBQueryCreator(PartTree tree,
@@ -22,12 +26,16 @@ public class DynamoDBQueryCreator<T,ID extends Serializable> extends AbstractDyn
 			DynamoDBEntityInformation<T, ID> entityMetadata,
 			DynamoDBOperations dynamoDBOperations) {
 		super(tree, parameterAccessor, entityMetadata, dynamoDBOperations);
+		pageable = parameterAccessor.getPageable();
 	}
-	
+
 	@Override
 	protected Query<T> complete(DynamoDBQueryCriteria<T, ID> criteria, Sort sort) {
 		if (sort != null) {
 			criteria.withSort(sort);
+		}
+		if (pageable != null) {
+			criteria.withPageable(pageable);
 		}
 
 		return criteria.buildQuery(dynamoDBOperations);

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCriteria.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.query.Query;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
@@ -40,6 +41,8 @@ public interface DynamoDBQueryCriteria<T, ID extends Serializable> {
 	public DynamoDBQueryCriteria<T, ID> withPropertyBetween(String segment, Object value1, Object value2, Class<?> type);
 
 	public DynamoDBQueryCriteria<T, ID> withSort(Sort sort);
+
+	public DynamoDBQueryCriteria<T, ID> withPageable(Pageable pageable);
 
 	public Query<T> buildQuery(DynamoDBOperations dynamoDBOperations);
 


### PR DESCRIPTION
This change respects the pagination size as provided from a Pageable
object given to a findXXX method.
Mostly important in conjunction with lazy list processing via

``` java
DynamoDBMapperConfig.Builder builder = new DynamoDBMapperConfig.Builder();
builder.setPaginationLoadingStrategy(PaginationLoadingStrategy.ITERATION_ONLY);
```

as this loads the result set of a query page-by-page.
Also see the comments in
`com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList<T>` as
used by
`org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate.query(Class<T>,
QueryRequest)`
