### PR TITLE
Fixes broken XML in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Download the jar though Maven:
 ```xml
 <repository>
 	<id>opensourceagility-release</id>
-	<url>http://repo.opensourceagility.com/release/</url
+	<url>http://repo.opensourceagility.com/release/</url>
 </repository>
 ```
 


### PR DESCRIPTION
Add missing `>` to close `url` tag in README markdown file.